### PR TITLE
feat: improve API + testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/metaform/dataplane-sdk-go
 go 1.24.1
 
 require (
+	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-playground/validator/v10 v10.27.0
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
+github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
+github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/tests/api_integration_test.go
+++ b/internal/tests/api_integration_test.go
@@ -11,8 +11,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	_ "github.com/lib/pq"
 	"github.com/metaform/dataplane-sdk-go/pkg/dsdk"
@@ -30,14 +32,24 @@ var database *sql.DB
 func newServerWithSdk(t *testing.T, sdk *dsdk.DataPlaneSDK) http.Handler {
 	t.Helper()
 	sdkApi := dsdk.NewDataPlaneApi(sdk)
-	mux := http.NewServeMux()
+	r := chi.NewRouter()
 
-	mux.HandleFunc("/start", sdkApi.Start)
-	mux.HandleFunc("/prepare", sdkApi.Prepare)
-	mux.HandleFunc("/terminate/", sdkApi.Terminate)
-	mux.HandleFunc("/suspend/", sdkApi.Suspend)
-	mux.HandleFunc("/status", sdkApi.Status)
-	return mux
+	r.Post("/dataflows/start", sdkApi.Start)
+	r.Post("/dataflows/{id}/start", func(writer http.ResponseWriter, request *http.Request) {
+		id := chi.URLParam(request, "id")
+		sdkApi.StartById(writer, request, id)
+	})
+	r.Post("/dataflows/prepare", sdkApi.Prepare)
+	r.Post("/dataflows/{id}/terminate", func(writer http.ResponseWriter, request *http.Request) {
+		id := chi.URLParam(request, "id")
+		sdkApi.Terminate(id, writer, request)
+	})
+	r.Post("/dataflows/{id}/suspend", func(writer http.ResponseWriter, request *http.Request) {
+		id := chi.URLParam(request, "id")
+		sdkApi.Suspend(id, writer, request)
+	})
+	r.Get("/dataflows/status", sdkApi.Status)
+	return r
 }
 
 var handler http.Handler
@@ -47,7 +59,7 @@ func TestMain(m *testing.M) {
 	database = db
 	t := &testing.T{}
 
-	sdk, err := createSdk(db)
+	sdk, err := newSdk(db)
 	assert.NoError(t, err)
 	handler = newServerWithSdk(t, sdk)
 	code := m.Run()
@@ -57,12 +69,12 @@ func TestMain(m *testing.M) {
 }
 
 // E2E tests
-func Test_Start_NotExists(t *testing.T) {
+func Test_Start_NotYetExists(t *testing.T) {
 
 	payload, err := serialize(newStartMessage())
 	assert.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, "/start", bytes.NewBuffer(payload))
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/start", bytes.NewBuffer(payload))
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -81,7 +93,7 @@ func Test_Start_InvalidPayload(t *testing.T) {
 	sm.CounterPartyID = "" // should raise a validation error
 	payload, err := serialize(sm)
 	assert.NoError(t, err)
-	req, err := http.NewRequest(http.MethodPost, "/start", bytes.NewBuffer(payload))
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/start", bytes.NewBuffer(payload))
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -90,11 +102,114 @@ func Test_Start_InvalidPayload(t *testing.T) {
 	assert.NotNil(t, rr.Body.String())
 }
 
+func Test_StartByID_WhenNotFound(t *testing.T) {
+	id := uuid.New().String()
+
+	requestBody, err := serialize(newStartByIdMessage())
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/"+id+"/start", bytes.NewBuffer(requestBody))
+	assert.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+
+}
+
+func Test_StartByID_WhenStartedOrStarting(t *testing.T) {
+
+	states := []dsdk.DataFlowState{
+		dsdk.Started,
+		dsdk.Starting,
+	}
+
+	for _, state := range states {
+		id := uuid.New().String()
+		store := postgres.NewStore(database)
+		flow, err := newFlowBuilder().ID(id).State(state).Build()
+		assert.NoError(t, err)
+		assert.NoError(t, store.Create(ctx, flow))
+
+		requestBody, err := serialize(newStartByIdMessage())
+		assert.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "/dataflows/"+id+"/start", bytes.NewBuffer(requestBody))
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		found, err := store.FindById(ctx, id)
+		assert.NoError(t, err)
+		assert.Equal(t, dsdk.Started, found.State)
+	}
+
+}
+
+func Test_StartByID_WhenPrepared(t *testing.T) {
+
+	tests := []struct {
+		isConsumer       bool
+		expectedHttpCode int
+		expectedState    dsdk.DataFlowState
+	}{
+		{
+			isConsumer:       true,
+			expectedHttpCode: http.StatusOK,
+			expectedState:    dsdk.Started,
+		},
+		{
+			isConsumer:       false,
+			expectedHttpCode: http.StatusBadRequest,
+			expectedState:    dsdk.Prepared,
+		},
+	}
+
+	for _, test := range tests {
+		id := uuid.New().String()
+		store := postgres.NewStore(database)
+		flow, err := newFlowBuilder().ID(id).State(dsdk.Prepared).Consumer(test.isConsumer).Build()
+		assert.NoError(t, err)
+		assert.NoError(t, store.Create(ctx, flow))
+
+		requestBody, err := serialize(newStartByIdMessage())
+		assert.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "/dataflows/"+id+"/start", bytes.NewBuffer(requestBody))
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, test.expectedHttpCode, rr.Code)
+		found, err := store.FindById(ctx, id)
+		assert.NoError(t, err)
+		assert.Equal(t, test.expectedState, found.State)
+	}
+
+}
+
+func Test_StartByID_MissingSourceAddress(t *testing.T) {
+	requestBody, err := serialize(dsdk.DataFlowStartByIdMessage{})
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/some-id/start", bytes.NewBuffer(requestBody))
+	assert.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
 func Test_Prepare(t *testing.T) {
 	payload, err := serialize(newPrepareMessage())
 	assert.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, "/prepare", bytes.NewBuffer(payload))
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/prepare", bytes.NewBuffer(payload))
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -120,13 +235,90 @@ func Test_Prepare_WrongState(t *testing.T) {
 	payload, err := serialize(message)
 	assert.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, "/prepare", bytes.NewBuffer(payload))
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/prepare", bytes.NewBuffer(payload))
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusConflict, rr.Code)
+}
+
+func Test_Suspend_Success(t *testing.T) {
+
+	id := uuid.New().String()
+	flow, err := newFlowBuilder().ID(id).State(dsdk.Started).Build()
+	assert.NoError(t, err)
+	store := postgres.NewStore(database)
+	err = store.Create(ctx, flow)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/"+flow.ID+"/suspend", strings.NewReader(""))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	byId, err := store.FindById(ctx, id)
+	assert.NoError(t, err)
+	assert.Equal(t, dsdk.Suspended, byId.State)
+}
+
+func Test_Suspend_WhenNotExists(t *testing.T) {
+	id := uuid.New().String()
+	flow, err := newFlowBuilder().ID(id).State(dsdk.Started).Build()
+	assert.NoError(t, err)
+	//missing: storing the flow
+
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/"+flow.ID+"/suspend", strings.NewReader(""))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func Test_Suspend_WhenNotStarted(t *testing.T) {
+	id := uuid.New().String()
+	flow, err := newFlowBuilder().ID(id).State(dsdk.Completed).Build() // completed flows cannot transition to suspended
+	assert.NoError(t, err)
+	err = postgres.NewStore(database).Create(ctx, flow)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/"+flow.ID+"/suspend", strings.NewReader(""))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func Test_Terminate_Success(t *testing.T) {
+	id := uuid.New().String()
+	flow, err := newFlowBuilder().ID(id).State(dsdk.Started).Build()
+	assert.NoError(t, err)
+	store := postgres.NewStore(database)
+	err = store.Create(ctx, flow)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/"+flow.ID+"/terminate", strings.NewReader(""))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	byId, err := store.FindById(ctx, id)
+	assert.NoError(t, err)
+	assert.Equal(t, dsdk.Terminated, byId.State)
+}
+
+func Test_Terminate_WhenNotFound(t *testing.T) {
+	id := uuid.New().String()
+	flow, err := newFlowBuilder().ID(id).State(dsdk.Started).Build()
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "/dataflows/"+flow.ID+"/terminate", strings.NewReader(""))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
 
 func newFlowBuilder() *dsdk.DataFlowBuilder {
@@ -158,7 +350,21 @@ func newStartMessage() dsdk.DataFlowStartMessage {
 			TransferType:           newTransferType(),
 			DestinationDataAddress: dsdk.DataAddress{},
 		},
-		SourceDataAddress: &dsdk.DataAddress{},
+		SourceDataAddress: &dsdk.DataAddress{
+			Properties: map[string]any{
+				"foo": "bar",
+			},
+		},
+	}
+}
+
+func newStartByIdMessage() dsdk.DataFlowStartByIdMessage {
+	return dsdk.DataFlowStartByIdMessage{
+		SourceDataAddress: &dsdk.DataAddress{
+			Properties: map[string]any{
+				"foo": "bar",
+			},
+		},
 	}
 }
 
@@ -190,7 +396,7 @@ func newCallback() dsdk.CallbackURL {
 	return dsdk.CallbackURL{Scheme: "http", Host: "test.com", Path: "/callback"}
 }
 
-func createSdk(db *sql.DB) (*dsdk.DataPlaneSDK, error) {
+func newSdk(db *sql.DB) (*dsdk.DataPlaneSDK, error) {
 	sdk, err := dsdk.NewDataPlaneSDKBuilder().
 		Store(postgres.NewStore(db)).
 		TransactionContext(postgres.NewDBTransactionContext(db)).

--- a/pkg/dsdk/dsdk_test.go
+++ b/pkg/dsdk/dsdk_test.go
@@ -406,7 +406,7 @@ func Test_DataPlaneSDK_Terminate(t *testing.T) {
 		return df.State == Terminated
 	})).Return(nil)
 
-	err := dsdk.Terminate(ctx, "flow123")
+	err := dsdk.Terminate(ctx, "flow123", "")
 
 	assert.NoError(t, err)
 }
@@ -424,7 +424,7 @@ func Test_DataPlaneSDK_Terminate_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	store.EXPECT().FindById(ctx, "flow123").Return(nil, ErrNotFound)
-	err := dsdk.Terminate(ctx, "flow123")
+	err := dsdk.Terminate(ctx, "flow123", "")
 
 	assert.ErrorContains(t, err, "not found")
 }
@@ -449,7 +449,7 @@ func Test_DataPlaneSDK_Terminate_AlreadyTerminated(t *testing.T) {
 
 	// no transition and no save call expected
 
-	err := dsdk.Terminate(ctx, "flow123")
+	err := dsdk.Terminate(ctx, "flow123", "")
 
 	assert.NoError(t, err)
 }
@@ -471,7 +471,7 @@ func Test_DataPlaneSDK_Terminate_SdkCallbackError(t *testing.T) {
 		State: Started,
 	}, nil)
 
-	err := dsdk.Terminate(ctx, "flow123")
+	err := dsdk.Terminate(ctx, "flow123", "")
 
 	assert.ErrorContains(t, err, "some error")
 }
@@ -497,7 +497,7 @@ func Test_DataPlaneSDK_Suspend(t *testing.T) {
 		return df.State == Suspended
 	})).Return(nil)
 
-	err := dsdk.Suspend(ctx, "flow123")
+	err := dsdk.Suspend(ctx, "flow123", "")
 
 	assert.NoError(t, err)
 }
@@ -515,7 +515,7 @@ func Test_DataPlaneSDK_Suspend_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	store.EXPECT().FindById(ctx, "flow123").Return(nil, ErrNotFound)
-	err := dsdk.Suspend(ctx, "flow123")
+	err := dsdk.Suspend(ctx, "flow123", "")
 
 	assert.ErrorContains(t, err, "not found")
 }
@@ -540,7 +540,7 @@ func Test_DataPlaneSDK_Suspend_AlreadySuspended(t *testing.T) {
 
 	// no transition and no save call expected
 
-	err := dsdk.Suspend(ctx, "flow123")
+	err := dsdk.Suspend(ctx, "flow123", "")
 
 	assert.NoError(t, err)
 }
@@ -562,7 +562,7 @@ func Test_DataPlaneSDK_Suspend_SdkCallbackError(t *testing.T) {
 		State: Started,
 	}, nil)
 
-	err := dsdk.Suspend(ctx, "flow123")
+	err := dsdk.Suspend(ctx, "flow123", "")
 
 	assert.ErrorContains(t, err, "some error")
 }

--- a/pkg/dsdk/errors.go
+++ b/pkg/dsdk/errors.go
@@ -15,6 +15,8 @@ var (
 	ErrNotFound = errors.New("not found")
 	// ErrInvalidInput Sentinel error to indicate a wrong input, e.g. a string when a number was expected, or an empty string
 	ErrInvalidInput = errors.New("invalid input")
+	// ErrInvalidTransition Sentinel error to indicate an invalid state transition, e.g. of a data flow
+	ErrInvalidTransition = errors.New("invalid transition")
 )
 
 // NewValidationError Helper to create new ValidationError

--- a/pkg/dsdk/messages.go
+++ b/pkg/dsdk/messages.go
@@ -51,6 +51,18 @@ func (d *DataFlowStartMessage) Validate() error {
 	return nil
 }
 
+type DataFlowStartByIdMessage struct {
+	SourceDataAddress *DataAddress `json:"sourceDataAddress,omitempty" validate:"required"`
+}
+
+func (d *DataFlowStartByIdMessage) Validate() error {
+	err := v.Struct(d)
+	if err != nil {
+		return WrapValidationError(err)
+	}
+	return nil
+}
+
 type DataFlowPrepareMessage struct {
 	DataFlowBaseMessage
 }

--- a/pkg/dsdk/model_transition_test.go
+++ b/pkg/dsdk/model_transition_test.go
@@ -479,7 +479,7 @@ func TestDataFlow_transitionToSuspended(t *testing.T) {
 			initialStateCount := df.StateCount
 			initialTimestamp := df.StateTimestamp
 
-			err := df.TransitionToSuspended()
+			err := df.TransitionToSuspended("test-reason")
 
 			if tc.expectErr {
 				if err == nil {
@@ -678,7 +678,7 @@ func TestDataFlow_transitionToTerminated(t *testing.T) {
 			initialStateCount := df.StateCount
 			initialTimestamp := df.StateTimestamp
 
-			err := df.TransitionToTerminated()
+			err := df.TransitionToTerminated("test-reason")
 
 			if tc.expectErr {
 				if err == nil {


### PR DESCRIPTION
This PR improves on a few key aspects of the SDK:

- adds the `/dataflows/:id/start` endpoint
- adds a new message type `DataFlowStartByIdMessaage` that contains only the `sourceDataAddress`
- uses chi in tests, for proper URL path handling, which the standard HTTP router can't do
- invalid state transitions now add the `ErrInvalidTransition` error to their tree
- `terminate` and `suspend` operations now accept a `reason` parameter
